### PR TITLE
tweak: get the background restriction option faster

### DIFF
--- a/src/com/github/iusmac/sevensim/ApplicationInfo.java
+++ b/src/com/github/iusmac/sevensim/ApplicationInfo.java
@@ -83,13 +83,16 @@ public final class ApplicationInfo {
     }
 
     /**
-     * Get the activity intent to show screen of details about this application within the built-in
-     * Settings app.
+     * Get the activity intent to show screen of battery settings for this application within the
+     * built-in Settings app.
      */
-    public Intent getAppDetailsSettingsActivityIntent() {
-        final Intent i = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
-                Uri.parse("package:" + mPackageName));
-        i.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK);
+    public Intent getAppBatterySettingsActivityIntent() {
+        final String action = Utils.IS_AT_LEAST_S ? Settings.ACTION_VIEW_ADVANCED_POWER_USAGE_DETAIL
+            : "android.settings.APP_BATTERY_SETTINGS";
+        final Intent i = new Intent(action, Uri.parse("package:" + mPackageName));
+        // Highlight the preference fragment when launched
+        i.putExtra("request_ignore_background_restriction", true);
+        i.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
         return i;
     }
 

--- a/src/com/github/iusmac/sevensim/NotificationManager.java
+++ b/src/com/github/iusmac/sevensim/NotificationManager.java
@@ -70,7 +70,7 @@ public final class NotificationManager {
      */
     void showBackgroundRestrictedNotification() {
         final PendingIntent pIntent = PendingIntent.getActivityAsUser(mContext, /*requestCode=*/ 0,
-                mApplicationInfo.getAppDetailsSettingsActivityIntent(),
+                mApplicationInfo.getAppBatterySettingsActivityIntent(),
                 PendingIntent.FLAG_IMMUTABLE, /*options=*/ null, UserHandle.CURRENT);
 
         final String text = mResources.getString(R.string.background_restricted_notification_text);

--- a/src/com/github/iusmac/sevensim/ui/sim/SimListFragment.java
+++ b/src/com/github/iusmac/sevensim/ui/sim/SimListFragment.java
@@ -82,7 +82,7 @@ public final class SimListFragment extends Hilt_SimListFragment {
             .setAttentionLevel(BannerMessagePreference.AttentionLevel.HIGH)
             .setPositiveButtonText(R.string.background_restricted_button_prioritize_app)
             .setPositiveButtonOnClickListener((view) ->
-                startActivity(mApplicationInfoLazy.get().getAppDetailsSettingsActivityIntent()));
+                startActivity(mApplicationInfoLazy.get().getAppBatterySettingsActivityIntent()));
     }
 
     private void setupDisclaimerBanner() {


### PR DESCRIPTION
Launch battery settings instead of details screen about app.

Also, launch the activity at the top of the task stack instead of clearing the whole task while we're at it.