### PR TITLE
refactor(ui): wrap license layout using `LayoutPreference`

### DIFF
--- a/res/layout/license.xml
+++ b/res/layout/license.xml
@@ -3,25 +3,14 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:paddingStart="?android:attr/listPreferredItemPaddingStart"
+    android:paddingEnd="?android:attr/listPreferredItemPaddingEnd"
     android:orientation="vertical">
-    <androidx.core.widget.NestedScrollView
-        android:layout_width="match_parent"
-        android:layout_height="0dip"
-        android:layout_weight="1.0"
-        android:paddingStart="16dp"
-        android:paddingEnd="16dp"
-        android:scrollbarStyle="outsideOverlay">
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical">
-            <TextView
-                android:id="@+id/textView"
-                android:layout_height="match_parent"
-                android:layout_width="wrap_content"
-                android:padding="6dp"
-                android:autoLink="web|email"
-                android:textIsSelectable="true"/>
-        </LinearLayout>
-    </androidx.core.widget.NestedScrollView>
+
+    <TextView
+        android:id="@+id/textView"
+        android:layout_height="match_parent"
+        android:layout_width="wrap_content"
+        android:autoLink="web|email"
+        android:textIsSelectable="true"/>
 </LinearLayout>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -94,4 +94,5 @@
     <string name="preference_list_show_app_icon_key" translatable="false">"show_launcher_icon"</string>
     <string name="scheduler_pin_error_key" translatable="false">"scheduler_pin_error"</string>
     <string name="scheduler_empty_view_key" translatable="false">"scheduler_empty_view"</string>
+    <string name="license_key" translatable="false">"license"</string>
 </resources>

--- a/res/xml/license_preferences.xml
+++ b/res/xml/license_preferences.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <com.android.settingslib.widget.LayoutPreference
+        android:key="@string/license_key"
+        android:layout="@layout/license"
+        android:selectable="false" />
+</PreferenceScreen>

--- a/src/com/github/iusmac/sevensim/ui/license/LicenseFragment.java
+++ b/src/com/github/iusmac/sevensim/ui/license/LicenseFragment.java
@@ -2,36 +2,31 @@ package com.github.iusmac.sevensim.ui.license;
 
 import android.os.Bundle;
 import android.text.Spanned;
-import android.view.LayoutInflater;
 import android.view.View;
-import android.view.ViewGroup;
 import android.widget.TextView;
 
 import androidx.core.text.HtmlCompat;
 import androidx.preference.PreferenceFragmentCompat;
 
+import com.android.settingslib.widget.LayoutPreference;
+
 import com.github.iusmac.sevensim.R;
 
 public final class LicenseFragment extends PreferenceFragmentCompat {
     @Override
-    public View onCreateView(final LayoutInflater inflater, final ViewGroup container,
-            final Bundle savedInstanceState) {
-
-        return inflater.inflate(R.layout.license, container, false);
-    }
-
-    @Override
     public void onViewCreated(final View view, final Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
+        final LayoutPreference pref = findPreference(getString(R.string.license_key));
         final Spanned spanned = HtmlCompat.fromHtml(getString(R.string.license_html),
                 HtmlCompat.FROM_HTML_MODE_COMPACT);
 
-        final TextView textView = view.findViewById(R.id.textView);
+        final TextView textView = pref.findViewById(R.id.textView);
         textView.setText(spanned);
     }
 
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
+        addPreferencesFromResource(R.xml.license_preferences);
     }
 }


### PR DESCRIPTION
* This simplifies everything and also handles better scrolling since now it's inside preferences's RecyclerView.