### PR TITLE
build(deps): bump gradle/actions/setup-gradle from 3 to 4 in /.github/actions/android-build

### DIFF
--- a/.github/actions/android-build/action.yml
+++ b/.github/actions/android-build/action.yml
@@ -22,8 +22,6 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Validate Gradle wrapper checksum
-      uses: gradle/wrapper-validation-action@v2
     - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:
@@ -32,7 +30,7 @@ runs:
     - name: SettingsLibs cache warm up
       uses: ./.github/actions/settingslibs-cache-warm-up
     - name: Set up Gradle cache
-      uses: gradle/actions/setup-gradle@v3
+      uses: gradle/actions/setup-gradle@v4
       with:
         gradle-home-cache-cleanup: true
     - name: Build with Gradle


### PR DESCRIPTION
We also want to remove the redundant 'wrapper-validation' action, as starting with v4, the 'setup-gradle' action will perform wrapper validation on each execution by default:
https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#gradle-wrapper-validation