### PR TITLE
test(SimPinFeederTest): attempt to address test flakiness due to timeout

### DIFF
--- a/tests/test/java/com/github/iusmac/sevensim/telephony/SimPinFeederTest.java
+++ b/tests/test/java/com/github/iusmac/sevensim/telephony/SimPinFeederTest.java
@@ -900,8 +900,9 @@ public final class SimPinFeederTest extends MockitoHiltAndroidTestBase {
         await()
             .dontCatchUncaughtExceptions()
             .pollInSameThread()
-            .atMost(TASK_WAIT_TIMEOUT_DURATION.plusMillis(250L))
-            .atLeast(Duration.ofSeconds(3))
+            .atMost(TASK_WAIT_TIMEOUT_DURATION)
+            .atLeast(TASK_WAIT_TIMEOUT_DURATION.minusMillis(250L))
+            .pollInterval(Duration.ofMillis(50))
             .until(() -> mTask.getState() == TERMINATED);
     }
 


### PR DESCRIPTION
This occurs only on 'release' builds... presumably because of bytecode optimizations, which reduces overall execution time. To address this, we'll allow a max. discrepancy of 250ms.

```console
org.awaitility.core.ConditionTimeoutException: Condition was evaluated in 2 seconds 958 milliseconds which is earlier than expected minimum timeout 3 seconds
	at org.awaitility.core.ConditionAwaiter.await(ConditionAwaiter.java:172)
	at org.awaitility.core.CallableCondition.await(CallableCondition.java:78)
	at org.awaitility.core.CallableCondition.await(CallableCondition.java:26)
	at org.awaitility.core.ConditionFactory.until(ConditionFactory.java:1006)
	at org.awaitility.core.ConditionFactory.until(ConditionFactory.java:975)
	at com.github.iusmac.sevensim.telephony.SimPinFeederTest.assertTaskTimedOut(SimPinFeederTest.java:906)
	at com.github.iusmac.sevensim.telephony.SimPinFeederTest.test_ShouldFinishAfterExceedingFixedWaitTimeoutForSimStatusChangeEventWhenAvailableSimCardsDoNotRequirePin(SimPinFeederTest.java:219)
```	