### PR TITLE
test(UserAuthenticationObserverServiceTest): attempt to fix test flakiness

### DIFF
--- a/src/com/github/iusmac/sevensim/UserAuthenticationObserverService.java
+++ b/src/com/github/iusmac/sevensim/UserAuthenticationObserverService.java
@@ -226,7 +226,9 @@ public final class UserAuthenticationObserverService extends Hilt_UserAuthentica
          * @param task The {@link PendingTask} to offload onto a separate thread.
          */
         void schedule(final PendingTask task) {
-            mPendingTasks.offer(task);
+            if (!mReleased) {
+                mPendingTasks.offer(task);
+            }
         }
 
         @Override


### PR DESCRIPTION
When running this particular test inside a GitHub workflow, for some reason, sending the interrupt signal can take some time to be received by the Worker thread, so the LinkedBlockingQueue poll is not stopped and new tasks can still be "infiltrated", or, maybe the latter itself takes time to acquire a new ReentrantLock and enter the waiting state. Luckily, we have the mReleased flag, which we can use to further prevent new tasks from being added to the queue when Worker has been explicitly stopped.

```console
java.lang.AssertionError:
Expected: is <3>
     but: was <4>
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:6)
	at com.github.iusmac.sevensim.UserAuthenticationObserverServiceTest$TaskRunningLifecycle.test_onStartCommand_NoNewTasksShouldBeAcceptedAfterDestroyed(UserAuthenticationObserverServiceTest.java:365)
```