### PR TITLE
SchedulerActivityTest: make `test should defer list update when curre…

### DIFF
--- a/tests/test/java/com/github/iusmac/sevensim/ui/scheduler/SchedulerActivityTest.kt
+++ b/tests/test/java/com/github/iusmac/sevensim/ui/scheduler/SchedulerActivityTest.kt
@@ -3660,11 +3660,12 @@ class SchedulerActivityTest {
                         assertThat(mItemAdapter.itemCount, `is`(1))
                         assertTrue(listView.itemAnimator!!.isRunning())
 
-                        // Resume the choreographer and wait for another 249ms to reach 250ms
-                        // (RecyclerView's default animation change duration), in order to finish
-                        // the expansion animation and run all deferred tasks simultaneously
+                        // Resume the choreographer and draw the remaining frames, in order to
+                        // finish the expansion animation and run all deferred tasks simultaneously
+                        val delta = Duration.ofMillis(listView.itemAnimator!!.moveDuration)
+                            .minus(ShadowChoreographer.getFrameDelay())
                         ShadowChoreographer.setPaused(false)
-                        shadowOf(Looper.getMainLooper()).idleFor(Duration.ofMillis(249))
+                        shadowOf(Looper.getMainLooper()).idleFor(delta)
                         assertFalse(listView.itemAnimator!!.isRunning())
                         assertThat(mItemAdapter.itemCount, `is`(2))
                     }


### PR DESCRIPTION
...ntly animating` more robust

This is a follow-up improvement of the cb03fdc96a538d3ea77575d9c266116ed39d3ae2 commit. Here, we we use the public API to completely remove the dependency on the hardcoded duration constants to advance the Choreographer for a controlled drawing of the schedule expansion animation.