### PR TITLE
SimListActivityTest: address test flakiness

### DIFF
--- a/tests/test/java/com/github/iusmac/sevensim/ui/sim/SimListActivityTest.kt
+++ b/tests/test/java/com/github/iusmac/sevensim/ui/sim/SimListActivityTest.kt
@@ -723,6 +723,9 @@ class SimListActivityTest {
                 // Enable SIM card
                 onSimEntryAt(0).perform(switchClick())
 
+                // Wait for the ViewModel to process the async SIM state change request
+                waitActivityWorkerThreadUntilIdle()
+
                 sub = runBlocking {
                     val job = async(Dispatchers.Default) {
                         mSubscriptionsProvider.get().getSubscriptionForSubId(subInfo.subscriptionId)


### PR DESCRIPTION
After we click on the SIM entry switch, a SIM state change request will be posted on the worker thread through ViewModel, so need ensure it's finished before querying the updated values from the DB.

---

> Task :testDebugUnitTest

SimListActivityTest > com.github.iusmac.sevensim.ui.sim.SimListActivityTest$SimEntries.test should request SIM state change on toggle switch click (non-legacy RIL) FAILED
    java.lang.AssertionError at SimListActivityTest.kt:695

    Expected: is <1>
         but: was <2>
            at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
            at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:6)
            at com.github.iusmac.sevensim.ui.sim.SimListActivityTest$SimEntries$test should request SIM state change on toggle switch click (non-legacy RIL)$2.invoke(SimListActivityTest.kt:733)
            at com.github.iusmac.sevensim.ui.sim.SimListActivityTest$SimEntries$test should request SIM state change on toggle switch click (non-legacy RIL)$2.invoke(SimListActivityTest.kt:695)
            at com.github.iusmac.sevensim.ui.sim.SimListActivityTestKt.onActivity(SimListActivityTest.kt:923)
            at com.github.iusmac.sevensim.ui.sim.SimListActivityTestKt.onActivity$default(SimListActivityTest.kt:865)
            at com.github.iusmac.sevensim.ui.sim.SimListActivityTest$SimEntries.test should request SIM state change on toggle switch click (non-legacy RIL)(SimListActivityTest.kt:695)