### PR TITLE
test(SchedulerActivityTest): address test timeout due unhandled excep…

### DIFF
--- a/tests/test/java/com/github/iusmac/sevensim/ui/scheduler/SchedulerActivityTest.kt
+++ b/tests/test/java/com/github/iusmac/sevensim/ui/scheduler/SchedulerActivityTest.kt
@@ -1437,10 +1437,6 @@ class SchedulerActivityTest {
                         assertThat(mItemAdapter.getPosition(selectedSchedule.id), `is`(1))
                     }
                 }
-                // Wait for the ViewModel to complete before exiting the test, otherwise the
-                // database will be closed too early while there's an async schedule update request,
-                // that still interacts with it
-                waitActivityWorkerThreadUntilIdle()
             }
         }
 
@@ -1461,12 +1457,15 @@ class SchedulerActivityTest {
                     }
                 }
                 onView(withId(R.id.digital_clock)).captureRoboImage()
-
-                // Wait for the ViewModel to complete before exiting the test, otherwise the
-                // database will be closed too early while there's an async schedule update request,
-                // that still interacts with it
-                waitActivityWorkerThreadUntilIdle()
             }
+        }
+
+        @After
+        fun tearDown() {
+            // Wait for the ViewModel to complete before exiting the test, otherwise the database
+            // will be closed too early while there's an async schedule update request, that still
+            // interacts with it
+            waitActivityWorkerThreadUntilIdle()
         }
 
         private companion object {
@@ -1727,11 +1726,6 @@ class SchedulerActivityTest {
                         assertThat(typeface, `is`(nullValue()))
                     }
                 }
-
-                // Wait for the ViewModel to complete before exiting the test, otherwise the
-                // database will be closed too early while there's an async schedule update request,
-                // that still interacts with it
-                waitActivityWorkerThreadUntilIdle()
             }
         }
 
@@ -1823,6 +1817,14 @@ class SchedulerActivityTest {
             }
         }
 
+        @After
+        fun tearDown() {
+            // Wait for the ViewModel to complete before exiting the test, otherwise the database
+            // will be closed too early while there's an async schedule update request, that still
+            // interacts with it
+            waitActivityWorkerThreadUntilIdle()
+        }
+
         private companion object {
             fun onClockView(): ViewInteraction = onView(
                 both(withId(R.id.digital_clock))
@@ -1883,11 +1885,6 @@ class SchedulerActivityTest {
                     }
                 }
                 onEditLabel().check(matches(withEffectiveVisibility(Visibility.GONE)))
-
-                // Wait for the ViewModel to complete before exiting the test, otherwise the
-                // database will be closed too early while there's an async schedule update request,
-                // that still interacts with it
-                waitActivityWorkerThreadUntilIdle()
             }
         }
 
@@ -1990,11 +1987,6 @@ class SchedulerActivityTest {
                     }
                 }
                 onEditLabel().check(matches(withAlpha(ScheduleItemViewHolder.CLOCK_DISABLED_ALPHA)))
-
-                // Wait for the ViewModel to complete before exiting the test, otherwise the
-                // database will be closed too early while there's an async schedule update request,
-                // that still interacts with it
-                waitActivityWorkerThreadUntilIdle()
             }
         }
 
@@ -2030,6 +2022,15 @@ class SchedulerActivityTest {
                 onEditLabel().captureRoboImage()
             }
         }
+
+        @After
+        fun tearDown() {
+            // Wait for the ViewModel to complete before exiting the test, otherwise the database
+            // will be closed too early while there's an async schedule update request, that still
+            // interacts with it
+            waitActivityWorkerThreadUntilIdle()
+        }
+
 
         private companion object {
             fun onEditLabel(): ViewInteraction = onView(
@@ -2069,13 +2070,17 @@ class SchedulerActivityTest {
                 val appendLabel = " with appended text"
                 onEditText().perform(typeText(appendLabel), pressImeActionButton())
                 assertThat(schedule.label, `is`(label + appendLabel))
-
-                // Wait for the ViewModel to complete before exiting the test, otherwise the
-                // database will be closed too early while there's an async schedule update request,
-                // that still interacts with it
-                waitActivityWorkerThreadUntilIdle()
             }
         }
+
+        @After
+        fun tearDown() {
+            // Wait for the ViewModel to complete before exiting the test, otherwise the database
+            // will be closed too early while there's an async schedule update request, that still
+            // interacts with it
+            waitActivityWorkerThreadUntilIdle()
+        }
+
 
         private companion object {
             fun onEditText(): ViewInteraction = onView(withId(android.R.id.edit)).inRoot(isDialog())
@@ -2105,13 +2110,17 @@ class SchedulerActivityTest {
                     }
                 }
                 onEditLabel().captureRoboImage()
-
-                // Wait for the ViewModel to complete before exiting the test, otherwise the
-                // database will be closed too early while there's an async schedule update request,
-                // that still interacts with it
-                waitActivityWorkerThreadUntilIdle()
             }
         }
+
+        @After
+        fun tearDown() {
+            // Wait for the ViewModel to complete before exiting the test, otherwise the database
+            // will be closed too early while there's an async schedule update request, that still
+            // interacts with it
+            waitActivityWorkerThreadUntilIdle()
+        }
+
 
         private companion object {
             fun onEditLabel(): ViewInteraction = onView(
@@ -2142,11 +2151,6 @@ class SchedulerActivityTest {
                 scenario.onActivity {
                     assertThat(it.fragment.mSelectedSchedule, `is`(withId(schedule.id)))
                 }
-
-                // Wait for the ViewModel to complete before exiting the test, otherwise the
-                // database will be closed too early while there's an async schedule update request,
-                // that still interacts with it
-                waitActivityWorkerThreadUntilIdle()
             }
         }
 
@@ -2168,6 +2172,14 @@ class SchedulerActivityTest {
                     assertThat(it.fragment.mSelectedSchedule, `is`(nullValue()))
                 }
             }
+        }
+
+        @After
+        fun tearDown() {
+            // Wait for the ViewModel to complete before exiting the test, otherwise the database
+            // will be closed too early while there's an async schedule update request, that still
+            // interacts with it
+            waitActivityWorkerThreadUntilIdle()
         }
 
         private companion object {
@@ -2198,11 +2210,6 @@ class SchedulerActivityTest {
                         assertThat(mSelectedSchedule.enabled, `is`(newEnabled))
                     }
                 }
-
-                // Wait for the ViewModel to complete before exiting the test, otherwise the
-                // database will be closed too early while there's an async schedule update request,
-                // that still interacts with it
-                waitActivityWorkerThreadUntilIdle()
             }
         }
 
@@ -2226,11 +2233,6 @@ class SchedulerActivityTest {
                         assertThat(mSelectedSchedule.enabled, `is`(newEnabled))
                     }
                 }
-
-                // Wait for the ViewModel to complete before exiting the test, otherwise the
-                // database will be closed too early while there's an async schedule update request,
-                // that still interacts with it
-                waitActivityWorkerThreadUntilIdle()
             }
         }
 
@@ -2268,12 +2270,15 @@ class SchedulerActivityTest {
                 scenario.onActivity {
                     assertThat(it.fragment.mSelectedSchedule.enabled, `is`(newEnabled))
                 }
-
-                // Wait for the ViewModel to complete before exiting the test, otherwise the
-                // database will be closed too early while there's an async schedule update request,
-                // that still interacts with it
-                waitActivityWorkerThreadUntilIdle()
             }
+        }
+
+        @After
+        fun tearDown() {
+            // Wait for the ViewModel to complete before exiting the test, otherwise the database
+            // will be closed too early while there's an async schedule update request, that still
+            // interacts with it
+            waitActivityWorkerThreadUntilIdle()
         }
     }
 
@@ -2479,11 +2484,6 @@ class SchedulerActivityTest {
                 scenario.onActivity {
                     assertThat(it.fragment.mSelectedSchedule, `is`(withSubscriptionEnabled(false)))
                 }
-
-                // Wait for the ViewModel to complete before exiting the test, otherwise the
-                // database will be closed too early while there's an async schedule update request,
-                // that still interacts with it
-                waitActivityWorkerThreadUntilIdle()
             }
         }
 
@@ -2506,6 +2506,14 @@ class SchedulerActivityTest {
                     }
                 }
             }
+        }
+
+        @After
+        fun tearDown() {
+            // Wait for the ViewModel to complete before exiting the test, otherwise the database
+            // will be closed too early while there's an async schedule update request, that still
+            // interacts with it
+            waitActivityWorkerThreadUntilIdle()
         }
 
         private companion object {
@@ -2536,11 +2544,6 @@ class SchedulerActivityTest {
                         assertThat(mSelectedSchedule.subscriptionEnabled, `is`(newEnabled))
                     }
                 }
-
-                // Wait for the ViewModel to complete before exiting the test, otherwise the
-                // database will be closed too early while there's an async schedule update request,
-                // that still interacts with it
-                waitActivityWorkerThreadUntilIdle()
             }
         }
 
@@ -2564,11 +2567,6 @@ class SchedulerActivityTest {
                         assertThat(mSelectedSchedule.subscriptionEnabled, `is`(newEnabled))
                     }
                 }
-
-                // Wait for the ViewModel to complete before exiting the test, otherwise the
-                // database will be closed too early while there's an async schedule update request,
-                // that still interacts with it
-                waitActivityWorkerThreadUntilIdle()
             }
         }
 
@@ -2606,11 +2604,6 @@ class SchedulerActivityTest {
                 scenario.onActivity {
                     assertThat(it.fragment.mSelectedSchedule.subscriptionEnabled, `is`(newEnabled))
                 }
-
-                // Wait for the ViewModel to complete before exiting the test, otherwise the
-                // database will be closed too early while there's an async schedule update request,
-                // that still interacts with it
-                waitActivityWorkerThreadUntilIdle()
             }
         }
 
@@ -2631,11 +2624,6 @@ class SchedulerActivityTest {
                     }
                 }
                 onActionView().captureRoboImage()
-
-                // Wait for the ViewModel to complete before exiting the test, otherwise the
-                // database will be closed too early while there's an async schedule update request,
-                // that still interacts with it
-                waitActivityWorkerThreadUntilIdle()
             }
         }
 
@@ -2657,12 +2645,15 @@ class SchedulerActivityTest {
                     }
                 }
                 onActionView().captureRoboImage()
-
-                // Wait for the ViewModel to complete before exiting the test, otherwise the
-                // database will be closed too early while there's an async schedule update request,
-                // that still interacts with it
-                waitActivityWorkerThreadUntilIdle()
             }
+        }
+
+        @After
+        fun tearDown() {
+            // Wait for the ViewModel to complete before exiting the test, otherwise the database
+            // will be closed too early while there's an async schedule update request, that still
+            // interacts with it
+            waitActivityWorkerThreadUntilIdle()
         }
 
         private companion object {
@@ -2773,11 +2764,6 @@ class SchedulerActivityTest {
                     onDayOfWeek(index + 1).perform(click())
                     onDayOfWeek().captureRoboImage()
                 }
-
-                // Wait for the ViewModel to complete before exiting the test, otherwise the
-                // database will be closed too early while there's an async schedule update request,
-                // that still interacts with it
-                waitActivityWorkerThreadUntilIdle()
             }
         }
 
@@ -2799,11 +2785,6 @@ class SchedulerActivityTest {
                 scenario.onActivity {
                     assertThat(it.fragment.mSelectedSchedule, `is`(withId(schedule.id)))
                 }
-
-                // Wait for the ViewModel to complete before exiting the test, otherwise the
-                // database will be closed too early while there's an async schedule update request,
-                // that still interacts with it
-                waitActivityWorkerThreadUntilIdle()
             }
         }
 
@@ -2826,12 +2807,15 @@ class SchedulerActivityTest {
                     assertThat(it.fragment.mSelectedSchedule.daysOfWeek,
                         `is`(mDaysOfWeekFactory.create(SUNDAY, MONDAY, TUESDAY)))
                 }
-
-                // Wait for the ViewModel to complete before exiting the test, otherwise the
-                // database will be closed too early while there's an async schedule update request,
-                // that still interacts with it
-                waitActivityWorkerThreadUntilIdle()
             }
+        }
+
+        @After
+        fun tearDown() {
+            // Wait for the ViewModel to complete before exiting the test, otherwise the database
+            // will be closed too early while there's an async schedule update request, that still
+            // interacts with it
+            waitActivityWorkerThreadUntilIdle()
         }
 
         private companion object {
@@ -2886,11 +2870,6 @@ class SchedulerActivityTest {
                             `is`(wantedEnabled))
                     }
                 }
-
-                // Wait for the ViewModel to complete before exiting the test, otherwise the
-                // database will be closed too early while there's an async schedule update request,
-                // that still interacts with it
-                waitActivityWorkerThreadUntilIdle()
             }
         }
 
@@ -2918,11 +2897,6 @@ class SchedulerActivityTest {
                             `is`(wantedEnabled))
                     }
                 }
-
-                // Wait for the ViewModel to complete before exiting the test, otherwise the
-                // database will be closed too early while there's an async schedule update request,
-                // that still interacts with it
-                waitActivityWorkerThreadUntilIdle()
             }
         }
 
@@ -2963,12 +2937,15 @@ class SchedulerActivityTest {
                     assertThat(it.fragment.mSelectedSchedule.daysOfWeek.isBitOn(wantedDay),
                         `is`(wantedEnabled))
                 }
-
-                // Wait for the ViewModel to complete before exiting the test, otherwise the
-                // database will be closed too early while there's an async schedule update request,
-                // that still interacts with it
-                waitActivityWorkerThreadUntilIdle()
             }
+        }
+
+        @After
+        fun tearDown() {
+            // Wait for the ViewModel to complete before exiting the test, otherwise the database
+            // will be closed too early while there's an async schedule update request, that still
+            // interacts with it
+            waitActivityWorkerThreadUntilIdle()
         }
     }
 
@@ -3059,11 +3036,6 @@ class SchedulerActivityTest {
                         assertThat(mExpandedScheduleId, `is`(not(schedule.id)))
                     }
                 }
-
-                // Wait for the ViewModel to complete before exiting the test, otherwise the
-                // database will be closed too early while there's an async schedule removal
-                // request, that still interacts with it
-                waitActivityWorkerThreadUntilIdle()
             }
         }
 
@@ -3091,6 +3063,14 @@ class SchedulerActivityTest {
                 onView(withId(R.id.delete_confirm_container))
                     .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
             }
+        }
+
+        @After
+        fun tearDown() {
+            // Wait for the ViewModel to complete before exiting the test, otherwise the database
+            // will be closed too early while there's an async schedule update request, that still
+            // interacts with it
+            waitActivityWorkerThreadUntilIdle()
         }
 
         private companion object {
@@ -3129,11 +3109,6 @@ class SchedulerActivityTest {
                         assertThat(mSelectedSchedule, `is`(nullValue()))
                     }
                 }
-
-                // Wait for the ViewModel to complete before exiting the test, otherwise the
-                // database will be closed too early while there's an async schedule removal
-                // request, that still interacts with it
-                waitActivityWorkerThreadUntilIdle()
             }
         }
 
@@ -3157,11 +3132,6 @@ class SchedulerActivityTest {
                         assertThat(mSelectedSchedule, `is`(nullValue()))
                     }
                 }
-
-                // Wait for the ViewModel to complete before exiting the test, otherwise the
-                // database will be closed too early while there's an async schedule removal
-                // request, that still interacts with it
-                waitActivityWorkerThreadUntilIdle()
             }
         }
 
@@ -3200,12 +3170,15 @@ class SchedulerActivityTest {
                         assertThat(mSelectedSchedule, `is`(nullValue()))
                     }
                 }
-
-                // Wait for the ViewModel to complete before exiting the test, otherwise the
-                // database will be closed too early while there's an async schedule removal
-                // request, that still interacts with it
-                waitActivityWorkerThreadUntilIdle()
             }
+        }
+
+        @After
+        fun tearDown() {
+            // Wait for the ViewModel to complete before exiting the test, otherwise the database
+            // will be closed too early while there's an async schedule update request, that still
+            // interacts with it
+            waitActivityWorkerThreadUntilIdle()
         }
     }
 
@@ -3747,12 +3720,15 @@ class SchedulerActivityTest {
                     }
                 }
                 scenario.recreate()
-
-                // Wait for the ViewModel to complete before exiting the test, otherwise the
-                // database will be closed too early while there's an async schedule removal
-                // request, that still interacts with it
-                waitActivityWorkerThreadUntilIdle()
             }
+        }
+
+        @After
+        fun tearDown() {
+            // Wait for the ViewModel to complete before exiting the test, otherwise the database
+            // will be closed too early while there's an async schedule update request, that still
+            // interacts with it
+            waitActivityWorkerThreadUntilIdle()
         }
     }
 }


### PR DESCRIPTION
…tion in activity worker

The following tests timeout after 1 minute that occurs in the waitActivityWorkerThreadUntilIdle() function. This is caused by the unhandled exception in the activity worker thread, because a new test attempts to re-open the already-closed connection to the database (done in the tearDown method of the base class):

    Exception in thread "SchedulerActivityViewModelThread" java.lang.IllegalStateException: attempt to re-open an already-closed object: SQLiteDatabase: :memory:

After manual execution, there are some tests that missed the call to waitActivityWorkerThreadUntilIdle() needed to drain the activity worker thread before executing a new test (the rational behind this described in ef5757a64d39ed9fc018dcdae3a4a4571461b7fb). So, to avoid the same issue in the future, and also repeating ourselves multiple times, we'll always drain the activity worker thread after test finished.

---

> Task :testDebugUnitTest

SchedulerActivityTest > com.github.iusmac.sevensim.ui.scheduler.SchedulerActivityTest$TimeMutations.test should successfully create schedule with PIN when authentication not required FAILED
    java.util.concurrent.TimeoutException at SchedulerActivityTest.kt:1305

SchedulerActivityTest > com.github.iusmac.sevensim.ui.scheduler.SchedulerActivityTest$TimeMutations.test should rearrange schedules in the list when sorting criteria changed FAILED
    java.util.concurrent.TimeoutException at SchedulerActivityTest.kt:1425

SchedulerActivityTest > com.github.iusmac.sevensim.ui.scheduler.SchedulerActivityTest$TimeMutations.test should successfully create schedule without PIN when authentication is required FAILED
    java.util.concurrent.TimeoutException at SchedulerActivityTest.kt:1327

SchedulerActivityTest > com.github.iusmac.sevensim.ui.scheduler.SchedulerActivityTest$TimeMutations.test should reflect updated time in the selected schedule view FAILED
    java.util.concurrent.TimeoutException at SchedulerActivityTest.kt:1451

SchedulerActivityTest > com.github.iusmac.sevensim.ui.scheduler.SchedulerActivityTest$TimeMutations.test should update time in the selected schedule FAILED
    java.util.concurrent.TimeoutException at SchedulerActivityTest.kt:1380

SchedulerActivityTest > com.github.iusmac.sevensim.ui.scheduler.SchedulerActivityTest$TimeMutations.test should start authentication prompt activity when authentication is required FAILED
    java.util.concurrent.TimeoutException at SchedulerActivityTest.kt:1347

SchedulerActivityTest > com.github.iusmac.sevensim.ui.scheduler.SchedulerActivityTest$TimePickerDialog.test should successfully create schedule with picked time FAILED
    java.util.concurrent.TimeoutException at SchedulerActivityTest.kt:1274

SchedulerActivityTest > com.github.iusmac.sevensim.ui.scheduler.SchedulerActivityTest$Toolbar.test should refresh SIM name ONLY when the corresponding subscription changed FAILED
    java.util.concurrent.TimeoutException at SchedulerActivityTest.kt:364

SchedulerActivityTest > com.github.iusmac.sevensim.ui.scheduler.SchedulerActivityTest$Toolbar.test should regenerate time-sensitive data in SIM entries FAILED
    java.util.concurrent.TimeoutException at SchedulerActivityTest.kt:444

SchedulerActivityTest > com.github.iusmac.sevensim.ui.scheduler.SchedulerActivityTest$Toolbar.test should refresh next upcoming schedule summary on subscriptions changed FAILED
    java.util.concurrent.TimeoutException at SchedulerActivityTest.kt:387

SchedulerActivityTest > com.github.iusmac.sevensim.ui.scheduler.SchedulerActivityTest$Toolbar.test should regenerate locale-sensitive data FAILED
    java.util.concurrent.TimeoutException at SchedulerActivityTest.kt:413

SchedulerActivityTest > com.github.iusmac.sevensim.ui.scheduler.SchedulerActivityTest$Toolbar.test should refresh SIM name when the corresponding subscription changed FAILED
    java.util.concurrent.TimeoutException at SchedulerActivityTest.kt:332