### PR TITLE
chore(deps): upgrade Dagger/Hilt library to `v2.51`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         // https://mvnrepository.com/artifact/com.google.dagger/hilt-android
         // https://mvnrepository.com/artifact/com.google.dagger/hilt-compiler
         // https://android.googlesource.com/platform/external/dagger2
-        def hilt_version = '2.47'
+        def hilt_version = '2.51'
         // https://mvnrepository.com/artifact/io.github.takahirom.roborazzi/roborazzi
         roborazzi_version = '1.45.1'
         // https://mvnrepository.com/artifact/androidx.test.espresso/espresso-core


### PR DESCRIPTION
* As of android-15.0.0_r32 tag (ASB 2025-05)