### PR TITLE
build(Gradle): upgrade Android Gradle Plugin (AGP) to `v8.8.2`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -98,9 +98,9 @@ buildscript {
 
 plugins {
     // https://mvnrepository.com/artifact/com.android.application/com.android.application.gradle.plugin
-    id 'com.android.application' version '8.8.0' apply false
+    id 'com.android.application' version '8.8.2' apply false
     // https://mvnrepository.com/artifact/com.android.library/com.android.library.gradle.plugin
-    id 'com.android.library' version '8.8.0' apply false
+    id 'com.android.library' version '8.8.2' apply false
     // https://plugins.gradle.org/plugin/org.jetbrains.kotlin.android
     id 'org.jetbrains.kotlin.android' version '1.9.25' apply false
     // https://mvnrepository.com/artifact/net.ltgt.errorprone/net.ltgt.errorprone.gradle.plugin

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,7 +7,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.android.settings' version '8.8.0'
+    id 'com.android.settings' version '8.8.2'
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
../../settings.gradle:10: A newer version of com.android.settings than 8.8.0 is available: 8.11.0. (There is also a newer version of 8.8.𝑥 available, if upgrading to 8.11.0 is difficult: 8.8.2)