### PR TITLE
fix(CollapsingToolbarBaseActivity): handle `Expressive Design` theme

### DIFF
--- a/src/com/github/iusmac/sevensim/ui/components/CollapsingToolbarBaseActivity.java
+++ b/src/com/github/iusmac/sevensim/ui/components/CollapsingToolbarBaseActivity.java
@@ -13,6 +13,7 @@ import androidx.lifecycle.ViewModel;
 
 import com.android.settingslib.collapsingtoolbar.CollapsingToolbarDelegate;
 import com.android.settingslib.collapsingtoolbar.EdgeToEdgeUtils;
+import com.android.settingslib.widget.SettingsThemeHelper;
 
 import com.github.iusmac.sevensim.ui.components.toolbar.ToolbarDecorator;
 
@@ -41,6 +42,10 @@ public abstract class CollapsingToolbarBaseActivity extends FragmentActivity {
 
         EdgeToEdgeUtils.enable(this);
         super.onCreate(savedInstanceState);
+
+        if (SettingsThemeHelper.isExpressiveTheme(this)) {
+            setTheme(com.android.settingslib.widget.theme.R.style.Theme_SubSettingsBase_Expressive);
+        }
 
         final View view = getToolbarDelegate().onCreateView(getLayoutInflater(), null);
         super.setContentView(view);


### PR DESCRIPTION
Expressive design/theme is disabled by default on Android 15.

The 'is_expressive_design_enabled' system property can be used to enable it manually, though.

See for details https://android.googlesource.com/platform/frameworks/base/+/4efac66e05d181e9e4eb6d53c55bf4c44aa89987