### PR TITLE
fix(ui/AuthenticationPromptActivity): bring back translucency

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -153,7 +153,7 @@
             android:name=".ui.AuthenticationPromptActivity"
             android:excludeFromRecents="true"
             android:exported="false"
-            android:theme="@*android:style/Theme.DeviceDefault.Settings.Dialog.NoActionBar">
+            android:theme="@android:style/Theme.Translucent.NoTitleBar">
         </activity>
 
         <service


### PR DESCRIPTION
After SDK 35, the Theme.DeviceDefault.Settings.Dialog.NoActionBar theme seems to not have any translucency anymore when we display the authentication dialog.

As of built-in Settings app, the Theme.Translucent.NoTitleBar theme should be used for credential's indented activities. It's also a non-private theme.