### PR TITLE
test(AlarmReceiverTest): address flakiness when testing async operations

### DIFF
--- a/tests/test/java/com/github/iusmac/sevensim/scheduler/AlarmReceiverTest.java
+++ b/tests/test/java/com/github/iusmac/sevensim/scheduler/AlarmReceiverTest.java
@@ -285,7 +285,12 @@ public class AlarmReceiverTest extends MockitoHiltAndroidTestBase {
 
     /** Assert that {@link PendingResult#finish} has been called. */
     private void assertPendingResultFinished() {
-        assertTrue(shadowOf(shadowOf(mReceiver).getOriginalPendingResult()).getFuture().isDone());
+        await()
+            .dontCatchUncaughtExceptions()
+            .pollInSameThread()
+            .atMost(Duration.ofSeconds(2))
+            .pollInterval(Duration.ofMillis(50))
+            .until(shadowOf(shadowOf(mReceiver).getOriginalPendingResult()).getFuture()::isDone);
     }
 
     private static List<PinEntity> toPinEntityList(final Bundle clearPinCodes,


### PR DESCRIPTION
The following tests fail because the AlarmReceiver will call PendingResult.finish() in a separate thread, but we check for the result asap, so a race condition occurred.

Awaitility should be enough to avoid another potential race condition.

AlarmReceiverTest > onReceive_WithAllPinEntitiesMatchingAllPinStorageEntitiesExceptOneWhenBackgroundRestricted FAILED
    java.lang.AssertionError at AlarmReceiverTest.java:288
	at org.junit.Assert.fail(Assert.java:87)
	at org.junit.Assert.assertTrue(Assert.java:42)
	at org.junit.Assert.assertTrue(Assert.java:53)
	at com.github.iusmac.sevensim.scheduler.AlarmReceiverTest.assertPendingResultFinished(AlarmReceiverTest.java:288)
	at com.github.iusmac.sevensim.scheduler.AlarmReceiverTest.onReceive_WithAllPinEntitiesMatchingAllPinStorageEntitiesExceptOneWhenBackgroundRestricted(AlarmReceiverTest.java:266)

AlarmReceiverTest > onReceive_WithNoPinEntitiesWhenBackgroundRestricted FAILED
    java.lang.AssertionError at AlarmReceiverTest.java:288
	at org.junit.Assert.fail(Assert.java:87)
	at org.junit.Assert.assertTrue(Assert.java:42)
	at org.junit.Assert.assertTrue(Assert.java:53)
	at com.github.iusmac.sevensim.scheduler.AlarmReceiverTest.assertPendingResultFinished(AlarmReceiverTest.java:288)
	at com.github.iusmac.sevensim.scheduler.AlarmReceiverTest.onReceive_WithNoPinEntitiesWhenBackgroundRestricted(AlarmReceiverTest.java:205)