### PR TITLE
test(SubscriptionsComponentTest): fix failing instrumentation tests b…

### DIFF
--- a/src/com/github/iusmac/sevensim/telephony/Subscriptions.java
+++ b/src/com/github/iusmac/sevensim/telephony/Subscriptions.java
@@ -130,10 +130,10 @@ public abstract class Subscriptions implements Iterable<Subscription> {
         mUsableSubIdsSysProp = usableSimSubIdsSysProp;
         mSubscriptionsDao = appDatabase.subscriptionsDao();
 
-        // We use hidden API to create listener with a custom looper before Android 11.0 (R), on
+        // We use hidden API to create listener with a custom looper before Android 15.0 (V), on
         // newer versions, we can register the listener with a custom executor via
         // SubscriptionsImpl#addOnSubscriptionsChangedListener()
-        if (Utils.IS_AT_LEAST_R) {
+        if (Utils.IS_AT_LEAST_V) {
             mSubscriptionManagerListener =
             new SubscriptionManager.OnSubscriptionsChangedListener() {
                 @Override
@@ -391,7 +391,7 @@ public abstract class Subscriptions implements Iterable<Subscription> {
     private void registerSubscriptionManagerListener() {
         mLogger.v("registerSubscriptionManagerListener().");
 
-        if (Utils.IS_AT_LEAST_R) {
+        if (Utils.IS_AT_LEAST_V) {
             mSubscriptionManager.addOnSubscriptionsChangedListener(mContext.getMainExecutor(),
                     mSubscriptionManagerListener);
         } else {


### PR DESCRIPTION
…efore Android 14-QPR2

The instrumentation tests fail on Android 13, because we migrated to the newer API to create the listener too early. Only after the Android 14-QPR2 update the behavior was changed.

As of docs for SubscriptionManager.OnSubscriptionsChangedListener constructor, we should continue to use the deprecated hidden API to create the listener on versions prior to Android 15:

    > On OS versions prior to {@link Build.VERSION_CODES#VANILLA_ICE_CREAM} callers should
    > assume that this call will fail if invoked on a thread that does not already have a
    > prepared looper.

---

> Task :connectedDebugAndroidTest

com.github.iusmac.sevensim.telephony.SubscriptionsComponentTest > test_shouldReturnTheSameVisibleSubscriptionInfoListWhenQueriedBySubId[SM-A105FN - 13] FAILED
        java.lang.RuntimeException: Can't create handler inside thread Thread[Instr: com.github.iusmac.sevensim.HiltTestRunner,5,main] that has not called Looper.prepare()
        at android.os.Handler.<init>(Handler.java:227)

com.github.iusmac.sevensim.telephony.SubscriptionsComponentTest > test_shouldReturnTheSameVisibleSubscriptionInfoListWhenQueriedBySimSlotIndex_SinceR[SM-A105FN - 13] FAILED
        java.lang.RuntimeException: Can't create handler inside thread Thread[Instr: com.github.iusmac.sevensim.HiltTestRunner,5,main] that has not called Looper.prepare()
        at android.os.Handler.<init>(Handler.java:227)