### PR TITLE
chore(deps): upgrade `Dagger/Hilt` library to `v2.55`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         // https://mvnrepository.com/artifact/com.google.dagger/hilt-android
         // https://mvnrepository.com/artifact/com.google.dagger/hilt-compiler
         // https://android.googlesource.com/platform/external/dagger2
-        def hilt_version = '2.51'
+        def hilt_version = '2.55'
         // https://mvnrepository.com/artifact/io.github.takahirom.roborazzi/roborazzi
         roborazzi_version = '1.45.1'
         // https://mvnrepository.com/artifact/androidx.test.espresso/espresso-core


### PR DESCRIPTION
* As of android-16.0.0_r1 (ASB 2025-06)