### PR TITLE
feat(ToolbarDecorator): enable fading and scrolling of long subtitles

### DIFF
--- a/src/com/github/iusmac/sevensim/ui/components/toolbar/SubtitleTextView.java
+++ b/src/com/github/iusmac/sevensim/ui/components/toolbar/SubtitleTextView.java
@@ -1,7 +1,6 @@
 package com.github.iusmac.sevensim.ui.components.toolbar;
 
 import android.content.Context;
-import android.text.TextUtils;
 
 import androidx.appcompat.widget.AppCompatTextView;
 
@@ -10,6 +9,5 @@ abstract class SubtitleTextView extends AppCompatTextView {
         super(context);
 
         setIncludeFontPadding(false);
-        setEllipsize(TextUtils.TruncateAt.END);
     }
 }

--- a/src/com/github/iusmac/sevensim/ui/components/toolbar/ToolbarDecorator.java
+++ b/src/com/github/iusmac/sevensim/ui/components/toolbar/ToolbarDecorator.java
@@ -2,6 +2,7 @@ package com.github.iusmac.sevensim.ui.components.toolbar;
 
 import android.content.Context;
 import android.text.TextUtils;
+import android.text.method.ScrollingMovementMethod;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
@@ -390,11 +391,13 @@ public final class ToolbarDecorator {
         CollapsedSubtitle(final Context context) {
             super(context);
 
-
             setFactory(() -> new SubtitleTextView(context) {
                 {
                     setTextAppearance(R.style.TextAppearance_CollapsingToolbarCollapsedSubtitle);
                     setSingleLine();
+                    setHorizontalFadingEdgeEnabled(true);
+                    setHorizontallyScrolling(true);
+                    setMovementMethod(new ScrollingMovementMethod());
                 }
             });
         }


### PR DESCRIPTION
Fading is better than ellipsis that always consumes 3 characters.

NOTE: this applies only to the collapsed subtitle view since the expanded subtitle view no longer suffers from excessively long texts after cb8b7e5c6526476860e1f5c089d6d2a06d08627d ("ToolbarDecorator: support auto-adjustable collapsing toolbar height when expanded") commit.