### PR TITLE
fix(CollapsingToolbarBaseActivity): ensure content is scrolled beneath toolbar

### DIFF
--- a/res/values/integers.xml
+++ b/res/values/integers.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Override the default AOSP's value of 50ms, which is too short and makes the scrim flicker
+        on <60Hz displays.
+        Note that for a better UI, we completely disable the scrim background animation in the
+        Expressive Design, otherwise we'll see for a moment the scrollable content through the
+        AppBarLayout. -->
+    <integer name="collapsingtoolbar_scrim_anim_duration">250</integer>
+    <integer name="collapsingtoolbar_scrim_anim_duration_expressive">0</integer>
+</resources>

--- a/src/com/github/iusmac/sevensim/ui/components/CollapsingToolbarBaseActivity.java
+++ b/src/com/github/iusmac/sevensim/ui/components/CollapsingToolbarBaseActivity.java
@@ -34,8 +34,6 @@ import java.util.Optional;
  * the box.
  */
 public abstract class CollapsingToolbarBaseActivity extends FragmentActivity {
-    private static final int SCRIM_ANIMATION_DURATION = 250;
-
     private CollapsingToolbarDelegate mToolbardelegate;
     private ToolbarDecorator mToolbarDecorator;
     private ViewModel mViewModel;
@@ -58,9 +56,10 @@ public abstract class CollapsingToolbarBaseActivity extends FragmentActivity {
 
         final ToolbarDecorator toolbarDecorator = getToolbarDecorator();
         if (toolbarDecorator.isCollapsingToolbarSupported()) {
-            // Override the default AOSP's value of 50ms, which is too short and makes the scrim
-            // flicker on <60Hz displays
-            getCollapsingToolbarLayout().setScrimAnimationDuration(SCRIM_ANIMATION_DURATION);
+            final int scrimAnimationDuration = getResources().getInteger(isExpressiveTheme ?
+                    R.integer.collapsingtoolbar_scrim_anim_duration_expressive
+                    : R.integer.collapsingtoolbar_scrim_anim_duration);
+            getCollapsingToolbarLayout().setScrimAnimationDuration(scrimAnimationDuration);
             // Enforce fade in/out and translate collapse effect for the title so that it's
             // consistent with the subtitle that doesn't support scaling, which may be selected if
             // using non-AOSP sources
@@ -84,6 +83,9 @@ public abstract class CollapsingToolbarBaseActivity extends FragmentActivity {
                 // Hide the action button by default when expressive theme is enabled.
                 setActionButtonEnabled(false);
             }
+            // Our use case requires the CollapsingToolbar to be permanently lifted above the
+            // scrollable content (safe to disable; less animations, better performance)
+            getAppBarLayout().setLiftable(false);
         } else {
             // For better UX (e.g. l10n), apply the marquee effect on the title for non-collapsing
             // Toolbar


### PR DESCRIPTION
Fixes #82.

By default, the appbar starts as not lifted, then it's lifted on scroll. That's why the scrollable content is not beneath the toolbar as seen in #82. Our use case doesn't require appbar lifting, so we can safely disable this feature, making the toolbar be permanently lifted above the scrollable content.

This would likely be a bug in the material-components library, which doesn't properly handle the edge-to-edge enforcement since Android 15.

NOTE: whereas disabling lifting feature fixes the view drawing order (aka Z order), for a better UI, we also need to disable the scrim background animation in Expressive Design (enabled by default since Android 16), otherwise we'll see for a moment the scrollable content through the AppBarLayout.