### PR TITLE
test(SimListActivityTest): preemptively make background restricted banner visible

### DIFF
--- a/src/com/github/iusmac/sevensim/ui/sim/SimListFragment.java
+++ b/src/com/github/iusmac/sevensim/ui/sim/SimListFragment.java
@@ -82,7 +82,8 @@ public final class SimListFragment extends Hilt_SimListFragment {
             .setAttentionLevel(BannerMessagePreference.AttentionLevel.HIGH)
             .setPositiveButtonText(R.string.background_restricted_button_prioritize_app)
             .setPositiveButtonOnClickListener((view) ->
-                startActivity(mApplicationInfoLazy.get().getAppBatterySettingsActivityIntent()));
+                startActivity(mApplicationInfoLazy.get().getAppBatterySettingsActivityIntent()))
+            .setVisible(mActivityManager.isBackgroundRestricted());
     }
 
     private void setupDisclaimerBanner() {


### PR DESCRIPTION
We make the "Background usage required" banner preference visible in SimListFragment's onResume() method, but *sometimes* we get an ArrayIndexOutOfBoundsException from SettingsPreferenceGroupAdapter, which serves as a preferences decorator that updates their drawable's background round corners radius when expressive theme in enabled. The exception raises because the update preference list runnable is posted on the main thread, so that RecyclerView runs first. This is right to do and this issue cannot be reproduced when running on a real device, but it happens only in Robolectric tests, probably due to the paused looper and how Activity lifecycle chain is processed. (Could this be a bug in Robolectric?)

As a workaround, we'll preemptively make the banner visible during setup in SimListFragment's onViewCreated() method, so that it's present in the preference's adapter upon binding its view holder, which will pass through the SettingsPreferenceGroupAdapter decorator first and avoid the ArrayIndexOutOfBoundsException.

---

java.lang.ArrayIndexOutOfBoundsException: Index 6 out of bounds for length 6
	at com.android.settingslib.widget.SettingsPreferenceGroupAdapter.updateBackground(SettingsPreferenceGroupAdapter.kt:185)
	at com.android.settingslib.widget.SettingsPreferenceGroupAdapter.onBindViewHolder(SettingsPreferenceGroupAdapter.kt:96)
	at com.android.settingslib.widget.SettingsPreferenceGroupAdapter.onBindViewHolder(SettingsPreferenceGroupAdapter.kt:46)
	at androidx.recyclerview.widget.RecyclerView$Adapter.onBindViewHolder(RecyclerView.java:7846)
	at androidx.recyclerview.widget.RecyclerView$Adapter.bindViewHolder(RecyclerView.java:7953)
	at androidx.recyclerview.widget.RecyclerView$Recycler.tryBindViewHolderByDeadline(RecyclerView.java:6742)
	at androidx.recyclerview.widget.RecyclerView$Recycler.tryGetViewHolderForPositionByDeadline(RecyclerView.java:7013)
	at androidx.recyclerview.widget.RecyclerView$Recycler.getViewForPosition(RecyclerView.java:6853)
	at androidx.recyclerview.widget.RecyclerView$Recycler.getViewForPosition(RecyclerView.java:6849)
	at androidx.recyclerview.widget.LinearLayoutManager$LayoutState.next(LinearLayoutManager.java:2422)
	at androidx.recyclerview.widget.LinearLayoutManager.layoutChunk(LinearLayoutManager.java:1722)
	at androidx.recyclerview.widget.LinearLayoutManager.fill(LinearLayoutManager.java:1682)
	at androidx.recyclerview.widget.LinearLayoutManager.onLayoutChildren(LinearLayoutManager.java:747)
	at androidx.recyclerview.widget.RecyclerView.dispatchLayoutStep2(RecyclerView.java:4737)
	at androidx.recyclerview.widget.RecyclerView.dispatchLayout(RecyclerView.java:4459)
	at androidx.recyclerview.widget.RecyclerView.onLayout(RecyclerView.java:5011)
	[...]
	at org.robolectric.shadows.ShadowPausedLooper$IdlingRunnable.doRun(ShadowPausedLooper.java:677)
	at org.robolectric.shadows.ShadowPausedLooper$ControlRunnable.run(ShadowPausedLooper.java:599)
	at org.robolectric.shadows.ShadowPausedLooper$HandlerExecutor.execute(ShadowPausedLooper.java:849)
	at org.robolectric.shadows.ShadowPausedLooper.executeOnLooper(ShadowPausedLooper.java:765)
	at org.robolectric.shadows.ShadowPausedLooper.idle(ShadowPausedLooper.java:109)
	at org.robolectric.shadows.ShadowPausedLooper.idleIfPaused(ShadowPausedLooper.java:193)
	at org.robolectric.android.controller.ActivityController.visible(ActivityController.java:233)
	at org.robolectric.android.internal.RoboMonitoringInstrumentation.lambda$startActivitySyncInternal$0(RoboMonitoringInstrumentation.java:143)
	at org.robolectric.shadows.ShadowInstrumentation.runOnMainSyncNoIdle(ShadowInstrumentation.java:1183)
	at org.robolectric.android.internal.RoboMonitoringInstrumentation.startActivitySyncInternal(RoboMonitoringInstrumentation.java:125)
	at org.robolectric.android.internal.LocalActivityInvoker.startActivity(LocalActivityInvoker.java:38)
	at org.robolectric.android.internal.LocalActivityInvoker.startActivity(LocalActivityInvoker.java:43)
	at androidx.test.core.app.ActivityScenario.launchInternal(ActivityScenario.java:367)
	at androidx.test.core.app.ActivityScenario.launch(ActivityScenario.java:237)
	at com.github.iusmac.sevensim.ui.sim.SimListActivityTestKt.onActivity(SimListActivityTest.kt:992)
	at com.github.iusmac.sevensim.ui.sim.SimListActivityTestKt.onActivity$default(SimListActivityTest.kt:942)
	at com.github.iusmac.sevensim.ui.sim.SimListActivityTest$BackgroundRestrictedBanner.test full view when background usage restricted(SimListActivityTest.kt:218)