### PR TITLE
l10n(korean): fix formatting argument types incomplete or inconsistent lint warning

### DIFF
--- a/res/values-ko-rKR/strings.xml
+++ b/res/values-ko-rKR/strings.xml
@@ -25,8 +25,8 @@
     <string name="scheduler_delete_message">"이 작업은 되돌릴 수 없습니다. 계속 하시겠습니까?"</string>
     <string name="scheduler_days_of_week_none">"차단하지 않음"</string>
     <string name="scheduler_days_of_week_all">"매일"</string>
-    <string name="scheduler_start_time_custom_summary">"<![CDATA[<b><xliff:g name="date_time" example="today, 6 AM">%1$s</xliff:g></b>]]>에 자동으로 켜짐"</string>
-    <string name="scheduler_end_time_custom_summary">"<![CDATA[<b><xliff:g name="date_time" example="today, 10 PM">%1$s</xliff:g></b>]]>에 자동으로 꺼짐"</string>
+    <string name="scheduler_start_time_custom_summary">"<![CDATA[<b><xliff:g name="date_time" example="today, 6 AM">%1$s</xliff:g></b><xliff:g name="date_time_separator">%2$1s</xliff:g>]]>에 자동으로 켜짐"</string>
+    <string name="scheduler_end_time_custom_summary">"<![CDATA[<b><xliff:g name="date_time" example="today, 10 PM">%1$s</xliff:g></b><xliff:g name="date_time_separator">%2$1s</xliff:g>]]>에 자동으로 꺼짐"</string>
     <string name="scheduler_start_time_none_summary">"자동으로 켜지지 <b>않음</b>"</string>
     <string name="scheduler_end_time_none_summary">"자동으로 끄지 <b>않음</b>"</string>
     <string name="scheduler_no_schedule_summary">"일정 없음"</string>


### PR DESCRIPTION
Addressing the incomplete commit 0419351e30c02a636a3e6c4d6d611ca1b84f1be4 ("chore(SubscriptionSchedulerSummaryBuilder): add support for custom date-time separator").

---

```
/home/runner/work/7SIM/7SIM/res/values-ko-rKR/strings.xml:28: Warning: Inconsistent number of arguments in formatting string scheduler_start_time_custom_summary; found both 1 here and 2 in values/strings.xml [StringFormatCount]
    <string name="scheduler_start_time_custom_summary">"<![CDATA[<b><xliff:g name="date_time" example="today, 6 AM">%1$s</xliff:g></b>]]>에 자동으로 켜짐"</string>
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    /home/runner/work/7SIM/7SIM/res/values/strings.xml:54: Conflicting number of arguments (2) here
/home/runner/work/7SIM/7SIM/res/values-ko-rKR/strings.xml:29: Warning: Inconsistent number of arguments in formatting string scheduler_end_time_custom_summary; found both 1 here and 2 in values/strings.xml [StringFormatCount]
    <string name="scheduler_end_time_custom_summary">"<![CDATA[<b><xliff:g name="date_time" example="today, 10 PM">%1$s</xliff:g></b>]]>에 자동으로 꺼짐"</string>
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    /home/runner/work/7SIM/7SIM/res/values/strings.xml:55: Conflicting number of arguments (2) here

   Explanation for issues of type "StringFormatCount":
   When a formatted string takes arguments, it usually needs to reference the
   same arguments in all translations (or all arguments if there are no
   translations.

   There are cases where this is not the case, so this issue is a warning
   rather than an error by default. However, this usually happens when a
   language is not translated or updated correctly.
```