### PR TITLE
chore(ui): drain Handler thread queue when activity is destroyed

### DIFF
--- a/src/com/github/iusmac/sevensim/ui/scheduler/SchedulerActivity.java
+++ b/src/com/github/iusmac/sevensim/ui/scheduler/SchedulerActivity.java
@@ -160,4 +160,11 @@ public final class SchedulerActivity extends Hilt_SchedulerActivity
         mSubscriptions.removeOnSubscriptionsChangedListener(this);
         sHandler.removeCallbacksAndMessages(mSubscriptionsChangedToken);
     }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+
+        sHandler.removeCallbacksAndMessages(null);
+    }
 }

--- a/src/com/github/iusmac/sevensim/ui/sim/SimListActivity.java
+++ b/src/com/github/iusmac/sevensim/ui/sim/SimListActivity.java
@@ -145,6 +145,13 @@ public class SimListActivity extends Hilt_SimListActivity
         unregisterReceiver(mIntentReceiver);
     }
 
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+
+        sHandler.removeCallbacksAndMessages(null);
+    }
+
     @VisibleForTesting
     final class IntentReceiver extends BroadcastReceiver {
         @Override


### PR DESCRIPTION
Currently, we don't have any tasks that could execute after the Activity is destroyed and lead to crashes or unexpected behaviors. So, it's better to drain this static Handler thread's queue upon Activity destruction to prevent quite realistic, well-known bugs tied to Android lifecycle that we might face in the future if making any changes.